### PR TITLE
Exception handling refactor

### DIFF
--- a/ocbot1.py
+++ b/ocbot1.py
@@ -178,10 +178,11 @@ class Flair(object):
 	def set_flair(self):
 		count = self.__flair__()
 		flair_text = self.submission.author_flair_text
-		if flair_text:
+		try:
 			current_int = int(re.sub('OC:\s','',str(flair_text)[4:]))
-		else:
+		except ValueError:
 			current_int = 0
+
 		if count != None and count != 0 and str(self.submission.author_flair_css_class) not in self.special_flairs and current_int < count:
 			reddit.subreddit(str(self.subreddit)).flair.set(redditor=str(self.author),text='OC: {}'.format(count), css_class = 'ocmaker')
 			ocbotlog.getLogger().info('Flairing /u/{} with OC: {}'.format(self.author, count))

--- a/ocbot1.py
+++ b/ocbot1.py
@@ -177,7 +177,11 @@ class Flair(object):
 
 	def set_flair(self):
 		count = self.__flair__()
-		current_int = int(re.sub('OC:\s','',str(self.submission.author_flair_text)[4:]))
+		flair_text = self.submission.author_flair_text
+		if flair_text:
+			current_int = int(re.sub('OC:\s','',str(flair_text)[4:]))
+		else:
+			current_int = 0
 		if count != None and count != 0 and str(self.submission.author_flair_css_class) not in self.special_flairs and current_int < count:
 			reddit.subreddit(str(self.subreddit)).flair.set(redditor=str(self.author),text='OC: {}'.format(count), css_class = 'ocmaker')
 			ocbotlog.getLogger().info('Flairing /u/{} with OC: {}'.format(self.author, count))

--- a/ocbotlog.py
+++ b/ocbotlog.py
@@ -1,0 +1,15 @@
+import logging
+import sys
+
+LOGGER_NAME = "ocbotlog"
+
+def prep():
+    logger = logging.getLogger(LOGGER_NAME)
+    sh = logging.StreamHandler(sys.stdout)
+    fmt = logging.Formatter('[%(levelname)s] [%(asctime)s]: %(message)s')
+    sh.setFormatter(fmt)
+    logger.addHandler(sh)
+    logger.setLevel(logging.INFO)
+
+def getLogger():
+    return logging.getLogger(LOGGER_NAME)


### PR DESCRIPTION
Hello,

I made some changes to your bot, here's the TLDR differences:

- Exception handling moved to starter functions and some helpers
- Using the [`tenacity`](https://pypi.org/project/tenacity/) module to do automated retrying for the exceptions specified in `RECOVERABLE_EXCEPTIONS`.  
- Decoupled logging into a separate module in place of `print`, mostly because the `tenacity` module requires that to make use of its logging features.  It still outputs to stdout for the time being as you had before.  
- Exceptions other than `RECOVERABLE_EXCEPTIONS` are now logged then re-raised instead of being suppressed.  There might be other reasons you have for doing this, so I'll explain my reasoning for this more below.  

Reasons for changes:

You have an open issue regarding double posting.  I'm not sure what's causing it, but from my experience maintaining a Reddit bot of my own, I can say confidently that diagnosing it is difficult without somewhat sophisticated exception handling and logging.  Things looked a bit all over the place with the `try` blocks, so I cleaned it up to be easier to manage.  

`RECOVERABLE_EXCEPTIONS` is a tuple of exceptions from praw and requests that relate to networking errors.  I'd be lying if I said I knew what a couple of them mean, but in my experience maintaining /u/GGGGobbler they can be safely ignored and retried after waiting a bit (they cover things like the bot's connection dropping or reddit being down for maintenance)

Now, re-raising exceptions.  This is the only change in the bot's actual behaviour, so I'll justify it more here.  Predicting how software behaves after throwing network failure exceptions is reasonably possible, but it's a lot harder to do that for all exceptions generally.  Many exceptions may allow the bot to restart and try again without issue, but other exceptions could have undesirable effects.  

If you'll bear my anecdote, my bot had a critical bug in it some time ago that temporarily turned it into a spambot, and the chief reason being that I didn't re-raise a certain exception that was a really good reason for the bot to sit down and crash instead of getting back up and trying again (This was actually the result of a few problems happening at once including issues involving a database rollback, but it could have avoided being a spammer and bothering the subs' mods if I'd correctly allowed the exception to be raised and let the bot go offline until I tended to it manually). 

So that's why I made that change in my fork, so if there's a particular motivation for things like

```
try:
    comments = [comment for... #snip
except:
    return
```

that isn't covered by the new retry code, bring it up and we might figure out a safe way of doing it.  

A couple of notes:

- I don't _really_ know if the way the code is here is immune to double posting issues, but I believe it's a decent first step to diagnosing those kinds of problems.  I have a couple of ideas of the sorts of things that can cause double posting, but I'm not certain.  

- I'm assuming you haven't made much use of the method Sticky.error_handler(), since among other problems, `message` isn't even in scope for the `message.mark_read()` call.  I have a message control system in my bot that does what you might be trying here, though I don't suggest looking at mine for inspiration since it's fairly first-draft-ish if you get what I mean.  😳 
